### PR TITLE
add: code to do gradient_checkpointing

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -179,6 +179,9 @@ def main(run_name, debug=False):
             trust_remote_code=True,
             quantization_config=quant_config if isinstance(quant_config, BitsAndBytesConfig) else None,
         )
+        
+        # 그래디언트 체크포인팅 활성화
+        model.gradient_checkpointing_enable()
 
     if not train_args.do_train:
         latest_ckpt = sorted(os.listdir(model_args.model_name_or_path))[-1]
@@ -303,6 +306,7 @@ def main(run_name, debug=False):
                 save_total_limit=1,
                 save_only_model=True,
                 report_to="wandb",
+                gradient_checkpointing=True,  # 그래디언트 체크포인팅 활성화
             )
 
             trainer = SFTTrainer(


### PR DESCRIPTION
## Summary
그래디언트 체크포인팅을 활성화하는 코드를 추가
run.py과 argument.py는 개인마다 다르기 때문에 사용한 코드로 올리지 않음
리더보드 제출 코드 기준으로 run.py에서 quantization은 4,
arguments.py에서 모델은 Qwen/Qwen2.5-32B-Instruct,
max_seq_length는 700을 사용함

## Describe your changes
train과정에서 model.gradient_checkpointing_enable()
SFTConfig에서 gradient_checkpointing=True
추가로 기능 구현

## PR purpose
부족한 메모리와 계산비용을 trade off하여 메모리 한계를 극복하기 위함

## Additional Context
-